### PR TITLE
fix: add timeout + lock cleanup for claude setup hang

### DIFF
--- a/.github/workflows/hn-digest.yml
+++ b/.github/workflows/hn-digest.yml
@@ -161,8 +161,13 @@ jobs:
           git config user.name "claude-yolo[bot]"
           git config user.email "claude-yolo[bot]@users.noreply.github.com"
 
+      - name: clear claude locks
+        if: steps.check-digest.outputs.skip != 'true'
+        run: rm -rf ~/.local/state/claude/locks ~/.claude/.locks
+
       - name: let claude curate
         if: steps.check-digest.outputs.skip != 'true'
+        timeout-minutes: 8
         uses: thevibeworks/claude-code-action@main
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/hn-digest.yml
+++ b/.github/workflows/hn-digest.yml
@@ -167,7 +167,7 @@ jobs:
 
       - name: let claude curate
         if: steps.check-digest.outputs.skip != 'true'
-        timeout-minutes: 8
+        timeout-minutes: 15
         uses: thevibeworks/claude-code-action@main
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -344,3 +344,4 @@ jobs:
             - No fluff sections, no "skip" lists, no redundant summaries
             - ALWAYS BARK after creating the issue - this wakes up the human
             - If bark fails, try once more then move on (shit happens)
+


### PR DESCRIPTION
## Problem

Workflow stuck at \"Setting up Claude Code\" for 50+ minutes due to known upstream bugs:
- [#674](https://github.com/anthropics/claude-code-action/issues/674) - Code reviews timing out
- [#693](https://github.com/anthropics/claude-code-action/issues/693) - Setup timeouts
- [#709](https://github.com/anthropics/claude-code-action/issues/709) - Stale lock file

## Changes

1. **timeout-minutes: 8** on claude step
   - Healthy runs complete in ~6min
   - Setup alone takes ~6-8 seconds when working
   - Fail fast instead of burning 50min of compute

2. **Clear stale locks** before claude action
   - `rm -rf ~/.local/state/claude/locks ~/.claude/.locks`
   - Prevents \"another process is currently installing\" false positive

## Evidence

From successful run #20289313079:
```
02:15:50  Installing Claude Code...
02:15:52  Setting up Claude Code...
02:15:58  Installation complete!
```

Setup = 6 seconds. If it takes >1 min, it's hung.