### PR TITLE
fix(digest): stop filing a GitHub issue per digest

### DIFF
--- a/.github/workflows/hn-digest.yml
+++ b/.github/workflows/hn-digest.yml
@@ -27,7 +27,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      issues: write
       id-token: write
 
     steps:
@@ -303,11 +302,7 @@ jobs:
 
             8. Git add digests/ llms.txt index.html archive.html, commit, push
 
-            9. Create issue:
-               - Title: catchy 5-8 word summary capturing today's chaos
-               - Body: same content as digest file (highlights first!)
-
-            10. NOTIFY ALL CHANNELS:
+            9. NOTIFY ALL CHANNELS:
                BASE_URL: https://thevibeworks.github.io/claude-reads-hn
 
                ANCHOR FORMAT (CRITICAL - must match exactly):

--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ That's it. Claude handles the rest.
                     └──────┬──────┘     └─────────────┘
                            │
 ┌─────────────┐     ┌──────▼──────┐     ┌─────────────┐
-│  bark       │◀────│  claude     │────▶│  git commit │
-│  notify     │     │  picks 5,   │     │  + issue    │
-│             │     │  writes     │     │  + push     │
+│  bark + tg  │◀────│  claude     │────▶│  git commit │
+│  notify     │     │  picks 5,   │     │  + push     │
+│             │     │  writes     │     │  → pages    │
 └─────────────┘     └─────────────┘     └─────────────┘
 ```
 
@@ -83,8 +83,8 @@ That's it. Claude handles the rest.
 7. Claude picks 5 fresh stories with good discussion
 8. Claude writes digest JSON, converts to `digests/YYYY/MM/DD-HHMM.org` via skill scripts
 9. Skill scripts regenerate `llms.txt` index and `index.html`
-10. Git commit, push, create GitHub issue
-11. Bark notification with spiciest comment quote
+10. Git commit and push — the digest, `llms.txt`, and rendered pages
+11. Bark notification with spiciest comment quote, then Telegram/Discord
 12. Quota timer resets as happy side effect
 
 ## Secrets You Need
@@ -92,7 +92,7 @@ That's it. Claude handles the rest.
 | Secret | What | What Breaks Without It |
 |--------|------|----------------------|
 | `CLAUDE_CODE_OAUTH_TOKEN` | Claude Code OAuth token | Everything. Claude can't run. |
-| `CLAUDE_YOLO_APP_ID` | GitHub App ID | Can't commit or create issues. Run fails. |
+| `CLAUDE_YOLO_APP_ID` | GitHub App ID | Can't commit. Run fails. |
 | `CLAUDE_YOLO_APP_PRIVATE_KEY` | GitHub App private key | Same as above. |
 | `BARK_SERVER` | Bark push notification server URL | Bark notification fails. Digest still works. |
 | `BARK_DEVICES` | Bark device key(s) | Same. |
@@ -102,17 +102,21 @@ That's it. Claude handles the rest.
 
 Get the Claude token from: https://claude.com/settings/developer
 
-The GitHub App needs: `contents:write`, `issues:write` permissions.
+The GitHub App needs: `contents:write` permission.
 
 ## Notification Channels
 
-Digests are published to multiple channels:
-- **GitHub Issues** - Always (required)
+Every digest is committed to this repo and published to
+[the site](https://thevibeworks.github.io/claude-reads-hn) — that is the
+canonical archive. Notifications point at it:
+
 - **Bark** - iOS push notifications
-- **Telegram** - Channel/group messages
+- **Telegram** - Channel/group messages, one per story
 - **Discord** - Webhook messages
 
 Configure the secrets for the channels you want. Missing secrets = silent skip.
+
+The issue tracker is for bugs and feature requests, not digests.
 
 ## File Structure
 


### PR DESCRIPTION
## The problem

The digest pipeline opens one GitHub issue per run, 8x/day since
2025-12-10. The tracker now holds **1,482 open issues and 1 closed**.

## Why the channel isn't load-bearing

Every digest is already published five other ways, all of them before
the issue step runs:

| Surface | Where |
|---|---|
| git | `digests/YYYY/MM/DD-HHMM.org` (1,476 files) |
| Pages site | `index.html` + `archive.html` — the canonical archive |
| agent index | `llms.txt` |
| push | Bark |
| chat | Telegram (`t.me/claudehn`), Discord |

Deleting the step loses no content.

## What the channel actually produced

Across 1,482 issues: **11 comments, 2 reactions, 0 assignees.** Every
comment is spam —

- `m13v` x7: LLM-written product pitches riding the digest topic
- `zhaog100`, `slipknoo822-lang`: `/attempt` and "I'd like to work on
  this bounty" — bounty bots mistaking digest issues for work items
- `skmski8399`: affiliate pitch

Meanwhile the only two real user reports, #825 and #855, have sat
unanswered since April, buried under the flood.

## Changes

- Drop step 9 (`Create issue`) from the agent prompt; renumber the
  notify step to 9
- Drop `issues: write` from the job's permissions (least privilege —
  nothing else in the workflow touches issues)
- README: the diagram, the numbered flow, the secrets table, and the
  Notification Channels section all advertised GitHub Issues as a
  required channel. Corrected to name the Pages site as canonical.

The GitHub App install still grants `issues:write`; that is set in App
settings, not here, and can be narrowed separately.

## Follow-up

The existing 1,482 will be bulk-closed as `not_planned` (not deleted —
content stays reachable), and #825/#855 answered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)