### PR TITLE
fix(schedule): cap digests at 4/day at the point of publication

### DIFF
--- a/.github/workflows/hn-digest.yml
+++ b/.github/workflows/hn-digest.yml
@@ -41,18 +41,35 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
 
-      - name: check if digest exists this hour
+      # Enforces the 4x/day contract at the point of publication rather than
+      # trusting the triggers. The per-hour check alone never did: this repo
+      # published 8 digests a day for months because a second scheduler fired
+      # on different hours, and GitHub's own cron drifts 1-3 hours, so "same
+      # hour" does not identify a duplicate. A daily cap does, and it holds no
+      # matter how many things dispatch this workflow.
+      - name: check digest quota for today
         id: check-digest
         run: |
+          MAX_PER_DAY=4
           HOUR_PREFIX=$(date -u +%Y/%m/%d-%H)
+          DAY_PREFIX=$(date -u +%Y/%m/%d)
+
           EXISTING=$(ls digests/$HOUR_PREFIX*.org digests/$HOUR_PREFIX*.md 2>/dev/null || true)
           if [ -n "$EXISTING" ]; then
             echo "Digest already exists for this hour: $EXISTING"
             echo "skip=true" >> $GITHUB_OUTPUT
-          else
-            echo "No digest for hour $HOUR_PREFIX, proceeding"
-            echo "skip=false" >> $GITHUB_OUTPUT
+            exit 0
           fi
+
+          TODAY_COUNT=$(ls digests/$DAY_PREFIX-*.org digests/$DAY_PREFIX-*.md 2>/dev/null | wc -l | tr -d ' ')
+          if [ "$TODAY_COUNT" -ge "$MAX_PER_DAY" ]; then
+            echo "Already published $TODAY_COUNT digests today (cap $MAX_PER_DAY); skipping."
+            echo "skip=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "No digest for hour $HOUR_PREFIX; $TODAY_COUNT/$MAX_PER_DAY published today, proceeding"
+          echo "skip=false" >> $GITHUB_OUTPUT
 
       - name: fetch hacker news with content
         if: steps.check-digest.outputs.skip != 'true'


### PR DESCRIPTION
Follow-up to #1493. That PR removed one of the two schedulers; this makes the
4x/day contract hold **regardless of how many schedulers exist**.

## Why the existing guard never helped

The workflow already checked "does a digest exist for this hour". It never
caught the duplication, because the two schedulers fired on *different* hours:

```
CF Worker        01:00  06:00  11:00  20:00   (exact)
GitHub cron      04:12  08:40  12:55  17:35   (1-3h drift)
```

Every one of those eight runs passed a same-hour check. The repo published 8
digests a day for eight months with the guard working exactly as written.

## Why not a minimum-interval guard

That was my first instinct and it is wrong here. GitHub's scheduled runs drift
one to three hours, so the gap between a *duplicate* and a legitimate *next
slot* overlaps. A 4-hour minimum would have blocked the 08:40 run as a
duplicate of 04:12, dropping the repo below 4/day. Drift makes interval
arithmetic unreliable.

## What this does

Counts today's committed digests and stops at 4. That is the documented
contract stated directly, and it is immune to trigger count, trigger source,
and cron drift.

```
4 existing today -> skip
3 existing today -> proceed
same hour already published -> skip (kept, it is cheap)
```

## Side effect worth having

The Cloudflare Worker is **still deployed** and I have no CF credentials to
tear it down (#1495). Until someone runs `wrangler delete`, it keeps
dispatching — but with this merged those runs exit at the guard: no Claude
quota spent, no Telegram post, no duplicate digest. The teardown becomes
housekeeping rather than a live problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)