### PR TITLE
workflow owns the edition slot: one timestamp for path, #+DATE, anchors, commit

### DIFF
--- a/.claude/skills/hn-digest/SKILL.md
+++ b/.claude/skills/hn-digest/SKILL.md
@@ -21,7 +21,8 @@ HN API (JSON) → Claude (curate) → .org file → HTML thread
 ```bash
 # 1. Fetch stories (workflow does this)
 # 2. Claude reads /tmp/hn/stories.json, writes digest
-# 3. Convert to org
+# 3. Convert to org. In the workflow, DIGEST_DATE and DIGEST_PATH are set
+#    and override the JSON date and the path argument (see json2org.py).
 python3 scripts/json2org.py /tmp/digest.json digests/2025/12/15-1100.org
 
 # 4. Build the site (all editions; only changed files are written)

--- a/.claude/skills/hn-digest/scripts/json2org.py
+++ b/.claude/skills/hn-digest/scripts/json2org.py
@@ -14,6 +14,7 @@ examples:
 
 import json
 import sys
+import os
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -156,12 +157,21 @@ def story_to_org(story: dict, level: int = 2) -> str:
 
 def digest_to_org(digest: dict) -> str:
     """Convert full digest JSON to org format."""
-    date = digest.get("date", datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"))
-
-    if "T" in date:
-        date_display = date.replace("T", " ").replace("Z", " UTC")[:22] + " UTC"
+    # The workflow fixes the edition's timestamp in DIGEST_DATE and it wins
+    # over whatever the curator wrote: a guessed date in the JSON must not
+    # reach the #+DATE header, the story anchors, or the file name.
+    json_date = digest.get("date")
+    env_date = os.environ.get("DIGEST_DATE")
+    if env_date:
+        if json_date and json_date != env_date:
+            print(f"json2org: JSON date {json_date} overridden by DIGEST_DATE {env_date}", file=sys.stderr)
+        date = env_date
     else:
-        date_display = date + " UTC"
+        date = json_date or datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    # "2026-09-02T11:00:00Z" -> "2026-09-02 11:00 UTC". The old slice
+    # produced "11:00:00 UT UTC" in every edition since the seconds arrived.
+    date_display = (date[:16].replace("T", " ") if "T" in date else date) + " UTC"
 
     org = f"""#+TITLE: HN Digest {date_display}
 #+DATE: {date}
@@ -195,6 +205,14 @@ def main():
 
     input_path = Path(sys.argv[1])
     output_path = Path(sys.argv[2]) if len(sys.argv) > 2 else None
+
+    # Same rule for the file name: DIGEST_PATH, when set, is where the
+    # edition lands, whatever path was passed on the command line.
+    env_path = os.environ.get("DIGEST_PATH")
+    if env_path:
+        if output_path and str(output_path) != env_path:
+            print(f"json2org: output {output_path} overridden by DIGEST_PATH {env_path}", file=sys.stderr)
+        output_path = Path(env_path)
 
     with open(input_path) as f:
         data = json.load(f)

--- a/.github/workflows/hn-digest.yml
+++ b/.github/workflows/hn-digest.yml
@@ -71,6 +71,25 @@ jobs:
           echo "No digest for hour $HOUR_PREFIX; $TODAY_COUNT/$MAX_PER_DAY published today, proceeding"
           echo "skip=false" >> $GITHUB_OUTPUT
 
+      # The workflow owns the edition's timestamp. Left to pick `date` itself,
+      # the curator got it wrong in 19 of 30 consecutive editions (hours off,
+      # sometimes the wrong day): files landed under the wrong day, the daily
+      # cap admitted a fifth edition, and "Nth of N today" on the site was
+      # fiction. One value, computed once, and the file path, #+DATE header,
+      # story anchors, notification links and commit message all derive from
+      # it. json2org.py enforces DIGEST_DATE/DIGEST_PATH even if the curator
+      # writes something else into the JSON.
+      - name: fix the edition slot
+        id: slot
+        if: steps.check-digest.outputs.skip != 'true'
+        run: |
+          NOW=$(date -u +%s)
+          echo "digest_date=$(date -u -d @$NOW +%Y-%m-%dT%H:%M:00Z)" >> $GITHUB_OUTPUT
+          echo "digest_path=digests/$(date -u -d @$NOW +%Y/%m/%d-%H%M).org" >> $GITHUB_OUTPUT
+          echo "anchor=$(date -u -d @$NOW +%m%d%H%M)" >> $GITHUB_OUTPUT
+          echo "display=$(date -u -d @$NOW '+%Y-%m-%d %H:%M')" >> $GITHUB_OUTPUT
+          echo "edition slot: $(date -u -d @$NOW +%Y-%m-%dT%H:%M:00Z)"
+
       - name: fetch hacker news with content
         if: steps.check-digest.outputs.skip != 'true'
         run: |
@@ -109,6 +128,7 @@ jobs:
 
           echo "# Hacker News Top Stories" > /tmp/hn/stories.md
           echo "Fetched at: $(date -u '+%Y-%m-%d %H:%M UTC')" >> /tmp/hn/stories.md
+          echo "Edition slot: ${{ steps.slot.outputs.digest_date }} -> ${{ steps.slot.outputs.digest_path }}" >> /tmp/hn/stories.md
           echo "" >> /tmp/hn/stories.md
 
           IDX=1
@@ -190,6 +210,8 @@ jobs:
           TG_BOT_TOKEN: ${{ secrets.TG_BOT_TOKEN }}
           TG_CHANNEL_ID: ${{ secrets.TG_CHANNEL_ID }}
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          DIGEST_DATE: ${{ steps.slot.outputs.digest_date }}
+          DIGEST_PATH: ${{ steps.slot.outputs.digest_path }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ steps.app-token.outputs.token }}
@@ -236,6 +258,13 @@ jobs:
 
             You are the HN curator. Read /tmp/hn/stories.md - it has titles, scores, comments, article previews.
 
+            THIS EDITION'S SLOT (fixed by the workflow; never compute or guess it):
+            - date:          ${{ steps.slot.outputs.digest_date }}
+            - org file:      ${{ steps.slot.outputs.digest_path }}
+            - anchor suffix: ${{ steps.slot.outputs.anchor }}
+            - commit line:   hn: ${{ steps.slot.outputs.display }} digest
+            Use exactly these for the JSON "date", the org path, every notification link, and the commit message.
+
             DO THE WORK:
 
             0. CHECK HISTORY (use hn-historian subagent):
@@ -260,7 +289,7 @@ jobs:
 
             ```json
             {
-              "date": "2025-12-15T11:00:00Z",
+              "date": "${{ steps.slot.outputs.digest_date }}",
               "vibe": "Roomba dies, Arduino goes corporate, and HN debates taxing our robot overlords",
               "highlights": [
                 "Roomba: Chinese supplier inherits the throne",
@@ -308,7 +337,7 @@ jobs:
             - comments array must match order of original comments
             - Keep: URLs, tags, usernames unchanged
 
-            5. CONVERT TO ORG: run ./.claude/skills/hn-digest/scripts/json2org.py /tmp/digest.json digests/YYYY/MM/DD-HHMM.org
+            5. CONVERT TO ORG: run ./.claude/skills/hn-digest/scripts/json2org.py /tmp/digest.json ${{ steps.slot.outputs.digest_path }}
 
             6. UPDATE MEMORY: run ./.claude/skills/hn-digest/scripts/llms-gen.py (regenerates llms.txt from all digests)
 
@@ -318,7 +347,7 @@ jobs:
                - e/YYYY/MM/DD-HHMM.html: one page per edition
                - archive.html, editions.json: the ledger and its index
 
-            8. Git add digests/ llms.txt index.html archive.html e/ editions.json, commit, push
+            8. Git add digests/ llms.txt index.html archive.html e/ editions.json, commit as "hn: ${{ steps.slot.outputs.display }} digest", push
 
             9. NOTIFY ALL CHANNELS:
                BASE_URL: https://thevibeworks.github.io/claude-reads-hn
@@ -385,7 +414,9 @@ jobs:
             LINK REFERENCE:
             - Base URL: https://thevibeworks.github.io/claude-reads-hn
             - Edition page: e/YYYY/MM/DD-HHMM.html from the digest date
+              (this edition: ${{ steps.slot.outputs.digest_path }} with .org -> .html, under e/ instead of digests/)
             - Anchor: #s{id}-{MMDDHHMM} (e.g., #s46268854-12271100)
+              (this edition: #s{id}-${{ steps.slot.outputs.anchor }})
             - Build: "s" + id + "-" + date[5:7] + date[8:10] + date[11:13] + date[14:16]
             - Example: digest "2025-12-27T11:00:00Z" + story 46268854 →
               https://thevibeworks.github.io/claude-reads-hn/e/2025/12/27-1100.html#s46268854-12271100

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,11 +8,21 @@ Instructions for the HN curator (that's you, Claude).
 2. Read `llms.txt` - your memory of all past digests (story IDs, topics covered)
 3. Pick 5 FRESH stories (never covered before, or covered but with 2x+ comment growth)
 4. Write digest JSON to `/tmp/digest.json` with translations
-5. Convert to org: `./.claude/skills/hn-digest/scripts/json2org.py /tmp/digest.json digests/YYYY/MM/DD-HHMM.org`
+5. Convert to org: `./.claude/skills/hn-digest/scripts/json2org.py /tmp/digest.json $DIGEST_PATH`
 6. Regenerate llms.txt: `./.claude/skills/hn-digest/scripts/llms-gen.py`
 7. Build the site: `./.claude/skills/hn-digest/scripts/org2html.py digests/*/*/*.org` (writes index.html, archive.html, e/, editions.json; only changed files are touched)
 8. Git add digests/ llms.txt index.html archive.html e/ editions.json, commit, push
 9. Send Bark notification with spiciest comment
+
+## The Edition Slot
+
+The workflow fixes the edition's timestamp before you start and hands it to
+you in the prompt and in the environment: `DIGEST_DATE`
+(`2026-09-02T11:00:00Z`) and `DIGEST_PATH` (`digests/2026/09/02-1100.org`).
+Never compute, round, or guess a date yourself. The JSON `date`, the org
+path, the story anchors (`#s{id}-{MMDDHHMM}`), the notification links and
+the commit message all derive from that one value; `json2org.py` enforces
+the two variables even if the JSON says otherwise.
 
 ## Digest Format
 
@@ -52,7 +62,7 @@ Instructions for the HN curator (that's you, Claude).
 }
 ```
 
-**Final File Path**: `digests/YYYY/MM/DD-HHMM.org`
+**Final File Path**: `$DIGEST_PATH`, always `digests/YYYY/MM/DD-HHMM.org`
 Example: `digests/2025/12/05-0900.org` for Dec 5, 09:00 UTC
 
 ## Translation Rules
@@ -126,8 +136,8 @@ mkdir -p digests/$(date -u +%Y/%m)
 # write digest JSON
 # (you do this with Write tool to /tmp/digest.json)
 
-# convert to org
-./.claude/skills/hn-digest/scripts/json2org.py /tmp/digest.json digests/2025/12/05-0900.org
+# convert to org (DIGEST_DATE / DIGEST_PATH from the workflow win over the JSON)
+./.claude/skills/hn-digest/scripts/json2org.py /tmp/digest.json "$DIGEST_PATH"
 
 # regenerate llms.txt from all digests
 ./.claude/skills/hn-digest/scripts/llms-gen.py
@@ -137,7 +147,7 @@ mkdir -p digests/$(date -u +%Y/%m)
 
 # commit everything
 git add digests/ llms.txt index.html archive.html e/ editions.json
-git commit -m "hn: $(date -u +%Y-%m-%d %H:%M) digest"
+git commit -m "hn: $(date -u -d "${DIGEST_DATE}" '+%Y-%m-%d %H:%M') digest"
 git push
 ```
 


### PR DESCRIPTION
## The defect

The curator picks the edition's `date` itself, and gets it wrong: in 19 of the last 30 editions the `#+DATE` hour differs from the commit hour, sometimes by a day (`digests/2026/08/30-0500.org` was committed 2026-08-29 07:47; `09/01-2300.org` at 09-01 01:05). Consequences, all reader-visible:

- files land under the wrong day, so the 4/day cap counted 5 editions on 2026-08-27 and 6 commits on 2026-08-24
- "Nth of N editions today" and the archive ledger are fiction for those days
- edition URLs carry times nobody published at

## The fix

The workflow computes the slot once, right after the quota check, and everything downstream derives from it:

| value | example | used for |
|---|---|---|
| `DIGEST_DATE` | `2026-09-02T11:00:00Z` | JSON `date`, `#+DATE` |
| `DIGEST_PATH` | `digests/2026/09/02-1100.org` | the org file, hence the `e/` page |
| anchor suffix | `09021100` | `#s{id}-…` in Telegram/Discord links |
| commit line | `hn: 2026-09-02 11:00 digest` | the commit message |

They are in the prompt (a "THIS EDITION'S SLOT" block, the JSON example, steps 5 and 8, the link reference) and in the curate step's environment. `json2org.py` enforces `DIGEST_DATE` and `DIGEST_PATH` over whatever the JSON or the command line say, with a stderr note when it overrides, so a guessed date cannot reach the file even if the curator ignores the prompt. `CLAUDE.md` and `SKILL.md` say the same thing, since the curator reads both (the lesson from #1511).

Also fixes the org title, which has read `HN Digest 2026-09-02 01:02:00 UT UTC` in every edition since seconds arrived (nothing renders it; still wrong).

## Verified

- `json2org.py` with a JSON dated `2026-09-01T23:00:00Z` and a wrong path, under `DIGEST_DATE=2026-09-02T11:00:00Z DIGEST_PATH=…/02-1100.org`: writes `02-1100.org` with `#+DATE: 2026-09-02T11:00:00Z` and logs both overrides. Without the variables: unchanged behaviour.
- workflow YAML parses; step order is quota check, slot, fetch, git, locks, curate.

The real test is the next scheduled run: its edition file, `#+DATE`, commit message and Telegram anchors should all carry the same timestamp, within a minute of the run's start.
