### PR TITLE
green means an edition landed; red opens an issue

### DIFF
--- a/.github/scripts/ci-alert.sh
+++ b/.github/scripts/ci-alert.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# ci-alert.sh -- make a failing digest run impossible to miss.
+#
+# Usage:
+#   .github/scripts/ci-alert.sh open <run-id>   # called on failure
+#   .github/scripts/ci-alert.sh close           # called on success
+#
+# This workflow runs several times a day and a red run has no reader: the
+# curator's notifications only fire after a successful push, so a run that
+# died before that (2026-09-02 05:32, "Spending cap reached", 481 ms) was
+# silent. The tripwire is one tracking issue labelled `ci-failure`: opened
+# on the first failure, commented on for each subsequent one, closed by the
+# next green run. Bounded at one open issue.
+#
+# Dedup never uses the search API: its index lags writes by minutes, which is
+# how a sibling repo once filed byte-identical duplicates 13 seconds apart.
+# The REST list lags too, by one to two seconds after a write (measured
+# 2026-09-02: a second `open` fired one second after the first created a
+# duplicate, with or without the label filter). So: match on title OR label
+# over the plain open-issues list, and before creating, look once more
+# after a short pause. Runs are hours apart, so the pause costs nothing
+# and the window is closed.
+#
+# Same script as claude-code-envs and claude-code-http-spec; only the words
+# differ. Uses the built-in GITHUB_TOKEN via GH_TOKEN.
+set -euo pipefail
+
+REPO="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY not set}"
+LABEL="ci-failure"
+TITLE="hn digest is failing"
+
+action="${1:-}"
+
+existing() {
+  gh api "repos/$REPO/issues?state=open&per_page=100" \
+    -q "[.[] | select(.pull_request == null) | select(.title == \"$TITLE\" or any(.labels[]?; .name == \"$LABEL\"))] | .[0].number // empty"
+}
+
+case "$action" in
+  open)
+    run_id="${2:?usage: $0 open <run-id>}"
+    run_url="https://github.com/$REPO/actions/runs/$run_id"
+    num="$(existing)"
+    if [[ -z "$num" ]]; then
+      sleep 3
+      num="$(existing)"
+    fi
+    if [[ -n "$num" ]]; then
+      gh api "repos/$REPO/issues/$num/comments" -f body="Still failing: $run_url" >/dev/null
+      echo "ci-alert: commented on existing #$num" >&2
+    else
+      gh api "repos/$REPO/labels" -f name="$LABEL" -f color=b60205 \
+        -f description="A scheduled digest run is red" >/dev/null 2>&1 || true
+      num="$(gh api "repos/$REPO/issues" -f title="$TITLE" -f "labels[]=$LABEL" \
+        -f body="A scheduled \`hn digest\` run failed before an edition reached main.
+
+Failing run: $run_url
+
+This issue closes automatically on the next green run. If it stays open,
+readers are not getting editions. The usual causes: the Claude OAuth
+token at its spending cap, a GitHub Actions outage, or the curate step
+timing out." -q .number)"
+      echo "ci-alert: opened #$num" >&2
+    fi
+    ;;
+  close)
+    num="$(existing)"
+    if [[ -n "$num" ]]; then
+      gh api -X PATCH "repos/$REPO/issues/$num" -f state=closed -f state_reason=completed >/dev/null
+      echo "ci-alert: closed #$num (run is green again)" >&2
+    else
+      echo "ci-alert: nothing to close" >&2
+    fi
+    ;;
+  *)
+    echo "usage: $0 open <run-id> | close" >&2
+    exit 2
+    ;;
+esac

--- a/.github/workflows/hn-digest.yml
+++ b/.github/workflows/hn-digest.yml
@@ -28,6 +28,7 @@ jobs:
     permissions:
       contents: write
       id-token: write
+      issues: write          # ci-alert.sh tracking issue (one, auto-closed)
 
     steps:
       - name: Generate GitHub App token
@@ -88,6 +89,7 @@ jobs:
           echo "digest_path=digests/$(date -u -d @$NOW +%Y/%m/%d-%H%M).org" >> $GITHUB_OUTPUT
           echo "anchor=$(date -u -d @$NOW +%m%d%H%M)" >> $GITHUB_OUTPUT
           echo "display=$(date -u -d @$NOW '+%Y-%m-%d %H:%M')" >> $GITHUB_OUTPUT
+          echo "page_path=e/$(date -u -d @$NOW +%Y/%m/%d-%H%M).html" >> $GITHUB_OUTPUT
           echo "edition slot: $(date -u -d @$NOW +%Y-%m-%dT%H:%M:00Z)"
 
       - name: fetch hacker news with content
@@ -422,3 +424,33 @@ jobs:
               https://thevibeworks.github.io/claude-reads-hn/e/2025/12/27-1100.html#s46268854-12271100
             - Minutes required: digests like 0240.org and 0259.org need distinct anchors
 
+      # A green run must mean an edition on main. The curate step exits 0
+      # whenever Claude finishes, whether or not it wrote, built, or pushed
+      # anything, so until now "success" and "did nothing" were the same
+      # colour. Assert the artifact, not the exit code.
+      - name: verify the edition landed
+        if: steps.check-digest.outputs.skip != 'true'
+        run: |
+          git fetch -q origin main
+          missing=0
+          for f in "${{ steps.slot.outputs.digest_path }}" "${{ steps.slot.outputs.page_path }}"; do
+            if git cat-file -e "origin/main:$f" 2>/dev/null; then
+              echo "landed: $f"
+            else
+              echo "::error::$f is not on origin/main after the curate step"
+              missing=1
+            fi
+          done
+          exit $missing
+
+      - name: alert on failure
+        if: failure() && steps.check-digest.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: .github/scripts/ci-alert.sh open "${{ github.run_id }}"
+
+      - name: clear alert on success
+        if: success() && steps.check-digest.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: .github/scripts/ci-alert.sh close


### PR DESCRIPTION
## Two gaps, one PR

**A green run did not mean an edition.** The curate step exits 0 whenever Claude finishes, whether or not it wrote the org file, built the page, or pushed. "Success" and "did nothing" were the same colour. Now, after curate, the run asserts that this slot's `digests/…org` and `e/…html` (from #1513's slot) are on `origin/main`, and fails naming the missing file if not.

**A red run had no reader.** The curator's Bark/Telegram/Discord fire only after a successful push, so this morning's 05:32 failure ("Spending cap reached", 481 ms into the curate step) reached nobody. `.github/scripts/ci-alert.sh` is the same instrument claude-code-envs and claude-code-http-spec have had since August: one tracking issue labelled `ci-failure`, opened on the first failure, commented on for each further one, closed automatically by the next green run. `issues: write` is added to the job for it.

## Tested

Live against this repo (issues since deleted):

- `open` twice one second apart originally produced **two** issues: the REST issue list, with or without the label filter, lags a write by 1–2 s. The August note that the label-filtered list is safe was only true at run spacing. Fixed by matching title-or-label over the plain open list and rechecking once after 3 s before creating. Retest: `open`, `open`, `close` → one issue, one "still failing" comment, closed.
- Workflow YAML parses; the new steps run only when the quota check did not skip.

The same dedup hardening should go to envs and http-spec; separate PRs.