### PR TITLE
tell "out of quota" apart from "broken"

### DIFF
--- a/.github/scripts/ci-alert.sh
+++ b/.github/scripts/ci-alert.sh
@@ -1,16 +1,29 @@
 #!/usr/bin/env bash
-# ci-alert.sh -- make a failing digest run impossible to miss.
+# ci-alert.sh -- make a failing digest run impossible to miss, and say which
+# kind of failure it was.
 #
 # Usage:
-#   .github/scripts/ci-alert.sh open <run-id>   # called on failure
-#   .github/scripts/ci-alert.sh close           # called on success
+#   .github/scripts/ci-alert.sh open <run-id> [quota|defect]   # on failure
+#   .github/scripts/ci-alert.sh close                          # on success
 #
 # This workflow runs several times a day and a red run has no reader: the
 # curator's notifications only fire after a successful push, so a run that
 # died before that (2026-09-02 05:32, "Spending cap reached", 481 ms) was
-# silent. The tripwire is one tracking issue labelled `ci-failure`: opened
-# on the first failure, commented on for each subsequent one, closed by the
-# next green run. Bounded at one open issue.
+# silent. The tripwire is a tracking issue: opened on the first failure,
+# commented on for each subsequent one, closed by the next green run.
+#
+# Two channels, because there are two problems. Every failure this tripwire
+# has caught so far was the shared Claude OAuth token at its cap, which is a
+# capacity problem Eric owns at the account level and no commit here can fix.
+# A broken script is a defect this repo owns. Filing both under one title
+# means the twentieth quota notice buries the first real bug -- red stops
+# meaning anything, the same way green did before the verify step landed.
+# So: `quota` and `ci-failure` are separate rolling issues, one open at most
+# each, and a green run closes both.
+#
+# The quota issue counts its comments rather than staying quiet, because the
+# useful question is not "are we out?" but "how often?" -- that is the number
+# that decides whether the bots need a seat of their own.
 #
 # Dedup never uses the search API: its index lags writes by minutes, which is
 # how a sibling repo once filed byte-identical duplicates 13 seconds apart.
@@ -22,60 +35,118 @@
 # to 15 s. Runs are hours apart, so the wait costs nothing on the path
 # that matters and the window is closed on the path that does not.
 #
-# Same script as claude-code-envs and claude-code-http-spec; only the words
-# differ. Uses the built-in GITHUB_TOKEN via GH_TOKEN.
+# Same script as claude-code-envs, claude-code-http-spec and deepseek-docs;
+# only the words differ. Uses the built-in GITHUB_TOKEN via GH_TOKEN.
 set -euo pipefail
 
 REPO="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY not set}"
-LABEL="ci-failure"
-TITLE="hn digest is failing"
+
+DEFECT_LABEL="ci-failure"
+DEFECT_TITLE="hn digest is failing"
+QUOTA_LABEL="quota"
+QUOTA_TITLE="hn digest is running out of Claude quota"
 
 action="${1:-}"
 
+# Open issue number for one channel, matched on title OR label so a
+# hand-retitled or hand-relabelled issue is still found.
 existing() {
+  local title="$1" label="$2"
   gh api "repos/$REPO/issues?state=open&per_page=100" \
-    -q "[.[] | select(.pull_request == null) | select(.title == \"$TITLE\" or any(.labels[]?; .name == \"$LABEL\"))] | .[0].number // empty"
+    -q "[.[] | select(.pull_request == null) | select(.title == \"$title\" or any(.labels[]?; .name == \"$label\"))] | .[0].number // empty"
 }
 
 case "$action" in
   open)
-    run_id="${2:?usage: $0 open <run-id>}"
+    run_id="${2:?usage: $0 open <run-id> [quota|defect]}"
+    reason="${3:-defect}"
     run_url="https://github.com/$REPO/actions/runs/$run_id"
-    num="$(existing)"
-    for _ in 1 2 3 4 5; do
-      [[ -n "$num" ]] && break
-      sleep 3
-      num="$(existing)"
-    done
-    if [[ -n "$num" ]]; then
-      gh api "repos/$REPO/issues/$num/comments" -f body="Still failing: $run_url" >/dev/null
-      echo "ci-alert: commented on existing #$num" >&2
+
+    if [[ "$reason" == "quota" ]]; then
+      title="$QUOTA_TITLE"; label="$QUOTA_LABEL"; colour="fbca04"
+      label_desc="A run died because the Claude account hit its cap"
+      body="A scheduled \`hn digest\` run stopped because the Claude OAuth token
+hit its spending/session cap, so no edition was written.
+
+Failing run: $run_url
+
+This is capacity, not a defect: nothing in this repo can fix it. The token
+is shared with every other bot in the org and with interactive use, so a
+heavy session starves the digests. Each recurrence is one comment below --
+if they are piling up, the automation needs its own seat or API billing.
+
+Closes automatically on the next green run."
     else
-      gh api "repos/$REPO/labels" -f name="$LABEL" -f color=b60205 \
-        -f description="A scheduled digest run is red" >/dev/null 2>&1 || true
-      num="$(gh api "repos/$REPO/issues" -f title="$TITLE" -f "labels[]=$LABEL" \
-        -f body="A scheduled \`hn digest\` run failed before an edition reached main.
+      title="$DEFECT_TITLE"; label="$DEFECT_LABEL"; colour="b60205"
+      label_desc="A scheduled digest run is red"
+      body="A scheduled \`hn digest\` run failed before an edition reached main,
+for a reason that was not the Claude account's quota.
 
 Failing run: $run_url
 
 This issue closes automatically on the next green run. If it stays open,
-readers are not getting editions. The usual causes: the Claude OAuth
-token at its spending cap, a GitHub Actions outage, or the curate step
-timing out." -q .number)"
-      echo "ci-alert: opened #$num" >&2
+readers are not getting editions. The usual causes: a GitHub Actions
+outage, the curate step timing out, or a broken script."
+    fi
+
+    num="$(existing "$title" "$label")"
+    for _ in 1 2 3 4 5; do
+      [[ -n "$num" ]] && break
+      sleep 3
+      num="$(existing "$title" "$label")"
+    done
+
+    if [[ -n "$num" ]]; then
+      # Comment count is the running tally; the (N) makes the rate legible
+      # without opening the thread.
+      n=$(gh api "repos/$REPO/issues/$num/comments?per_page=100" -q 'length')
+      gh api "repos/$REPO/issues/$num/comments" \
+        -f body="Again ($((n + 2)) so far): $run_url" >/dev/null
+      echo "ci-alert: commented on existing #$num ($reason)" >&2
+    else
+      gh api "repos/$REPO/labels" -f name="$label" -f color="$colour" \
+        -f description="$label_desc" >/dev/null 2>&1 || true
+      num="$(gh api "repos/$REPO/issues" -f title="$title" -f "labels[]=$label" \
+        -f body="$body" -q .number)"
+      echo "ci-alert: opened #$num ($reason)" >&2
     fi
     ;;
   close)
-    num="$(existing)"
-    if [[ -n "$num" ]]; then
-      gh api -X PATCH "repos/$REPO/issues/$num" -f state=closed -f state_reason=completed >/dev/null
+    # A green run means neither condition holds, so clear both channels.
+    #
+    # Two traps here, both found by running this against a live repo:
+    #
+    # 1. `[[ $closed == 0 ]] && echo ...` as the last line exits 1 whenever
+    #    something WAS closed. This step runs under `if: success()`, so a
+    #    nonzero exit turns a green digest red, which fires the failure step,
+    #    which opens the very issue that was just closed. A tripwire that
+    #    manufactures the fault it watches for is worse than none.
+    # 2. The open-issues list lags a close by a second or two, so a second
+    #    `close` can still see the issue and report closing it again. Read
+    #    the issue's real state before claiming anything.
+    closed=0
+    for pair in "$DEFECT_TITLE|$DEFECT_LABEL" "$QUOTA_TITLE|$QUOTA_LABEL"; do
+      title="${pair%%|*}"; label="${pair##*|}"
+      num="$(existing "$title" "$label")"
+      [[ -n "$num" ]] || continue
+      state="$(gh api "repos/$REPO/issues/$num" -q .state)"
+      if [[ "$state" != "open" ]]; then
+        echo "ci-alert: #$num already closed (stale list)" >&2
+        continue
+      fi
+      gh api -X PATCH "repos/$REPO/issues/$num" -f state=closed \
+        -f state_reason=completed >/dev/null
       echo "ci-alert: closed #$num (run is green again)" >&2
-    else
+      closed=1
+    done
+    if [[ "$closed" == 0 ]]; then
       echo "ci-alert: nothing to close" >&2
     fi
     ;;
   *)
-    echo "usage: $0 open <run-id> | close" >&2
+    echo "usage: $0 open <run-id> [quota|defect] | close" >&2
     exit 2
     ;;
 esac
+
+exit 0

--- a/.github/workflows/hn-digest.yml
+++ b/.github/workflows/hn-digest.yml
@@ -204,6 +204,7 @@ jobs:
         run: rm -rf ~/.local/state/claude/locks ~/.claude/.locks
 
       - name: let claude curate
+        id: curate
         if: steps.check-digest.outputs.skip != 'true'
         timeout-minutes: 15
         uses: thevibeworks/claude-code-action@main
@@ -443,11 +444,46 @@ jobs:
           done
           exit $missing
 
+      # A red run is not always a broken run. Every digest failure since the
+      # tripwire went in has been the shared Claude OAuth token hitting its
+      # cap -- 2026-09-02 05:32 "Spending cap reached resets 6am", 10:55
+      # "...resets 11am" -- which no change in this repo can fix. Filed under
+      # the same title as a real defect, those turn the one channel that is
+      # supposed to mean "something broke" into a quota log, and the first
+      # genuine bug arrives looking like the twentieth false alarm. Capacity
+      # and defect are different problems with different owners, so they get
+      # different issues. The quota issue is not noise to be silenced: it
+      # counts occurrences, because "how often are the bots starving" is the
+      # number that decides whether this account needs its own seat.
+      - name: classify the failure
+        id: why
+        if: failure() && steps.check-digest.outputs.skip != 'true'
+        run: |
+          f="${{ steps.curate.outputs.execution_file }}"
+          reason=defect
+          if [ -n "$f" ] && [ -f "$f" ]; then
+            # Match the final result object only, never the whole file: the
+            # execution file carries the entire transcript, and this curator
+            # reads Hacker News, so a front-page story about API spending caps
+            # would otherwise file a genuine defect under "quota".
+            last_result=$(grep -Eo '"result": *"[^"]{0,300}' "$f" | tail -1 || true)
+            api_status=$(grep -Eo '"api_error_status": *[0-9]+' "$f" | tail -1 || true)
+            echo "final result: ${last_result:-<none>}"
+            if echo "$last_result" | grep -Eqi '(spending cap|session limit|usage limit|rate limit)' \
+               || echo "$api_status" | grep -Eq '429'; then
+              reason=quota
+            fi
+          fi
+          if [ "$reason" = quota ]; then
+            echo "::warning::out of Claude quota -- capacity, not a defect"
+          fi
+          echo "reason=$reason" >> $GITHUB_OUTPUT
+
       - name: alert on failure
         if: failure() && steps.check-digest.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
-        run: .github/scripts/ci-alert.sh open "${{ github.run_id }}"
+        run: .github/scripts/ci-alert.sh open "${{ github.run_id }}" "${{ steps.why.outputs.reason }}"
 
       - name: clear alert on success
         if: success() && steps.check-digest.outputs.skip != 'true'


### PR DESCRIPTION
Every failure the digest tripwire has caught since it landed this morning was capacity, not a defect:

| when | repo | what the model returned |
|---|---|---|
| 05:32 | claude-reads-hn | `Spending cap reached resets 6am` |
| 10:04 | claude-code-docs | 429 `You've hit your session limit · resets 11am (UTC)` |
| 10:55 | claude-reads-hn | `Spending cap reached resets 11am` |

Three failures, three capacity events, zero defects — and all of them filed as **"hn digest is failing"** under `ci-failure`.

That is the same rot the `verify the edition landed` step fixed this morning, pointed the other way. Green used to mean nothing because it did not assert an edition. Red now means nothing because it does not separate a problem this repo owns from one it cannot touch. At the current rate the first genuine bug shows up looking like the twentieth false alarm.

## What changes

`ci-alert.sh` classifies before it files. Two rolling channels, at most one open issue each, and a green run closes both:

- **`quota`** — the Claude account hit its cap. Nothing here can fix it. The issue **counts its recurrences**, because "how often are the bots starving" is the number that decides whether the automation needs its own seat, and right now nobody can answer it.
- **`ci-failure`** — anything else. This is the channel that should stay quiet, and now it can.

Anything unrecognised (missing execution file, unknown error) falls back to `ci-failure` — an unexplained failure belongs in the loud channel.

## The false-positive trap

Classification reads **only the final result object**, never the whole execution file. The file carries the entire transcript, and this curator reads Hacker News — a front-page story about API spending caps would otherwise file a real defect under `quota`. Tested with a fixture whose transcript is stuffed with "spending cap", "session limit" and "rate limit" but whose result is a `json2org.py` KeyError: classified `defect`.

## A bug this PR introduced, and the live test that caught it

The first draft ended `close` with `[[ "$closed" == 0 ]] && echo "nothing to close"`. That is false whenever something *was* closed, so the script exited 1. `clear alert on success` runs under `if: success()` — a green digest that cleared an alert would have failed the step, turned the run red, fired `alert on failure`, and re-opened the issue it had just closed. A tripwire that manufactures the fault it watches for is worse than no tripwire.

Fixed, and the close path now reads the issue's real state before claiming it closed anything (the open-issues list lags a close by a second or two — the same lag that drove the polling dedup).

## Verification

Ran against a live scratch repo, exit codes read rather than eyeballed:

| step | result | exit |
|---|---|---|
| `open <run> quota` | opened #4 | 0 |
| `open <run> defect` | opened #5, separate issue | 0 |
| `open <run> quota` again | commented, tally `Again (2 so far)`, `Again (3 so far)` | 0 |
| `close` | closed **both** #4 and #5 | 0 |
| `close` again | `nothing to close` | 0 |
| bad argument | usage | 2 |

Classifier against the two real signatures, the trap, and empty/missing file: `quota, quota, defect, defect, defect`.

Test repo was `lroolle/ci-alert-scratch` (private). I could not delete it — this token has no `delete_repo` scope — so it is still there and needs a manual delete.

## Not in this PR

The digest fired **117 runs in 14 days to publish 48 editions**: 57 skipped at the gate for ~0 tokens, 60 ran a full Opus curate, so 12 curates burned quota for nothing. Whether to drop a scheduling leg is a cost-vs-fill-rate call, not a bug — numbers and the recommendation go on #1495.
