### PR TITLE
run on opus-5, and stop calling a retired haiku

### DIFF
--- a/.claude/agents/hn-historian.md
+++ b/.claude/agents/hn-historian.md
@@ -2,7 +2,7 @@
 name: hn-historian
 description: Check HN story history for duplicates before curating. Use this to verify if a story or topic was already covered.
 tools: Read, Grep, Glob, Bash(date:*), Bash(grep:*), Bash(wc:*)
-model: haiku
+model: inherit
 ---
 
 You are the HN Historian - a fast, focused subagent that checks if stories have been covered before.

--- a/.github/workflows/hn-digest.yml
+++ b/.github/workflows/hn-digest.yml
@@ -214,20 +214,20 @@ jobs:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
           DIGEST_DATE: ${{ steps.slot.outputs.digest_date }}
           DIGEST_PATH: ${{ steps.slot.outputs.digest_path }}
-          # claude-code-action pins Claude Code 1.0.115, which hardcodes
-          # claude-3-5-haiku-20241022 as the only haiku it knows. That model is
-          # retired, so every call resolving to haiku returns
-          # 404 not_found_error: WebFetch (5 per edition) and the hn-historian
-          # subagent (model: haiku). Both fail silently -- the curator falls
-          # back to `curl r.jina.ai | head -300` and a plain grep of llms.txt,
-          # so editions still land and the run stays green. Pin the current
-          # Haiku until the action's Claude Code version is bumped.
+          # WebFetch summarises with whatever the haiku slot resolves to, and
+          # claude-code-action pins Claude Code 1.0.115, whose bundle hardcodes
+          # exactly one haiku: the retired claude-3-5-haiku-20241022. So all 5
+          # WebFetch calls per edition returned 404 not_found_error, silently --
+          # the curator fell back to `curl r.jina.ai | head -300` and the
+          # edition still landed, so nothing ever went red. This is the only
+          # lever for WebFetch's model; the hn-historian subagent is handled
+          # separately by `model: inherit`.
           ANTHROPIC_DEFAULT_HAIKU_MODEL: claude-haiku-4-5-20251001
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ steps.app-token.outputs.token }}
           claude_args: |
-            --model claude-opus-4-5-20251101
+            --model claude-opus-5
             --allowedTools Bash(git:*),Bash(gh:*),Bash(date:*),Bash(mkdir:*),Bash(curl:*),Read,Write,Edit,WebFetch,mcp__barkme__notify
             --mcp-config '{
               "mcpServers": {

--- a/.github/workflows/hn-digest.yml
+++ b/.github/workflows/hn-digest.yml
@@ -214,6 +214,15 @@ jobs:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
           DIGEST_DATE: ${{ steps.slot.outputs.digest_date }}
           DIGEST_PATH: ${{ steps.slot.outputs.digest_path }}
+          # claude-code-action pins Claude Code 1.0.115, which hardcodes
+          # claude-3-5-haiku-20241022 as the only haiku it knows. That model is
+          # retired, so every call resolving to haiku returns
+          # 404 not_found_error: WebFetch (5 per edition) and the hn-historian
+          # subagent (model: haiku). Both fail silently -- the curator falls
+          # back to `curl r.jina.ai | head -300` and a plain grep of llms.txt,
+          # so editions still land and the run stays green. Pin the current
+          # Haiku until the action's Claude Code version is bumped.
+          ANTHROPIC_DEFAULT_HAIKU_MODEL: claude-haiku-4-5-20251001
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## The symptom nobody saw

Every digest run is green. Editions land 4x/day, the site is fresh, no alert
issue is open. Inside the curate step, every run also does this:

```
API Error: 404 {"type":"not_found_error","message":"model: claude-3-5-haiku-20241022"}
```

5-9 times per edition. Sampled full-curate runs (gate-skips excluded - they
have no curate step to fail, and their ~14 KB logs read as health):

| run start | 404s |
|---|---|
| 2026-09-03T01:00Z | 5 |
| 2026-09-02T15:00Z | 6 |
| 2026-09-02T11:01Z | 5 |
| 2026-08-29T07:43Z | 9 |
| 2026-08-27T01:00Z | 9 |
| 2026-08-23T16:14Z | 6 |

Unbroken back to the edge of the 100-run window. Reproduce:

```sh
gh api repos/thevibeworks/claude-reads-hn/actions/runs/<id>/logs > /tmp/l.zip
unzip -p /tmp/l.zip '0_*' | grep -c 'model: claude-3-5-haiku'
```

It killed all 5 `WebFetch` calls (prompt step 3, "READ THE DAMN ARTICLE") and
the `hn-historian` subagent (step 0's FRESH/REVISIT/SKIP check). Neither is
fatal, which is why it survived: the curator falls back to
`curl r.jina.ai | head -300` and a grep of `llms.txt`, the edition lands,
`verify the edition landed` passes, `ci-alert.sh` closes.

Impact is quality and waste, not an outage. The missing historian sounded worse
than it measures - the workflow's own 24h `RECENT_IDS` dedup already covers
most of it. Since 2026-08-01: 146 editions, 730 story slots, 713 unique, 16
repeats (2%), nearly all same-day pairs.

## Cause: a frozen pin against a moving API

`claude-code-action` installs a fixed Claude Code (`action.yml:180`):

```
curl -fsSL https://claude.ai/install.sh | bash -s 1.0.115
```

Unpack it and every alias that build ships is a 2025 id:

```sh
npm pack @anthropic-ai/claude-code@1.0.115 && tar xzf *.tgz
```

| alias | resolves to in 1.0.115 |
|---|---|
| `sonnet` | `claude-sonnet-4-20250514` |
| `opus` | `claude-opus-4-1-20250805` |
| `haiku` | `claude-3-5-haiku-20241022` (retired -> the 404) |

`grep -o 'claude-3-5-haiku-[0-9]*' package/cli.js | sort -u` returns that one
id, three hits, no other haiku in the bundle.

## The changes

**1. Main model -> `claude-opus-5`.**

Safe because `--model` is only alias-matched against
`["sonnet","opus","haiku","sonnet[1m]","opusplan"]`; anything else passes
through to the API untouched. Proven empirically, not assumed: the workflow
already ran `claude-opus-4-5-20251101`, absent from 1.0.115's tables, and the
run's init event echoes it back as the live model.

**2. `hn-historian`: `model: haiku` -> `model: inherit`.**

Subagent frontmatter plays by a *different* rule - it is validated:

```js
if (!J31.includes(Z)) return `Invalid model "${Z}". Valid options: ${J31.join(", ")}`
// J31 = ["sonnet","opus","haiku","sonnet[1m]","opusplan","inherit"]
```

so a raw id is rejected there and the historian cannot name opus-5 directly.
`inherit` is the only option in that list not wired to a frozen id - it follows
the main model, so the historian rides along on opus-5.

**3. `ANTHROPIC_DEFAULT_HAIKU_MODEL: claude-haiku-4-5-20251001`.**

Now doing exactly one job: `WebFetch`, whose summariser resolves to the haiku
slot and has no other lever. 1.0.115 resolves it as
`env.ANTHROPIC_DEFAULT_HAIKU_MODEL ?? haiku35`, so the env var is the whole
fix. Env reaches the CLI - observed, not assumed: the curator reads
`$TG_BOT_TOKEN` out of this same step env today when it sends Telegram.

## Verify after merge

On the next full-curate run (duration > 90s; a gate-skip proves nothing):

```sh
unzip -p /tmp/l.zip '0_*' | grep -c 'model: claude-3-5-haiku'   # expect 0
unzip -p /tmp/l.zip '0_*' | grep -c '"name": "WebFetch"'        # expect ~5, no API Error after
unzip -p /tmp/l.zip '0_*' | grep -o '"model": "claude-opus-[0-9-]*"' | sort -u
```

If either new id is unreachable on the OAuth subscription token, the 404 comes
back naming that id rather than disappearing - the same grep tells us, and the
edition still lands via the fallbacks either way.

## Not fixed here

`claude-code-action` stays pinned to 1.0.115, and its bump workflow fires on a
`repository_dispatch` nobody sends. Every alias above keeps rotting. That is
the durable fix and belongs in that repo.

Separately: `DISCORD_WEBHOOK_URL` is unset - it prints empty in the run log
while every other secret prints `***` - so the Discord branch has been a no-op.
Intentional or forgotten; not touched here.
