### PR TITLE
use the upstream action instead of a fork nobody updates

### DIFF
--- a/.github/workflows/hn-digest.yml
+++ b/.github/workflows/hn-digest.yml
@@ -206,7 +206,7 @@ jobs:
       - name: let claude curate
         if: steps.check-digest.outputs.skip != 'true'
         timeout-minutes: 15
-        uses: thevibeworks/claude-code-action@main
+        uses: anthropics/claude-code-action@v1
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           TG_BOT_TOKEN: ${{ secrets.TG_BOT_TOKEN }}


### PR DESCRIPTION
Follow-up to #1525. That PR works around a dead model on the current runtime;
this one replaces the runtime, so the next retirement does not need a
workaround at all. Independent - either can merge first.

## The fork is not a fork

```
git rev-list --count upstream/main..origin/main   ->   0
git rev-list --count origin/main..upstream/main   ->   492
```

Zero custom commits. `thevibeworks/claude-code-action` is a mirror of
`anthropics/claude-code-action` that stopped moving, and its only consumer is
this workflow:

```sh
gh search code --owner thevibeworks 'thevibeworks/claude-code-action'
# thevibeworks/claude-reads-hn  .github/workflows/hn-digest.yml
```

The rest of the org already skipped it: `deva` uses `anthropics/...@v1`,
`claude-code-docs` and `deepseek-docs` use `@v1.0.168`. So this deletes a
dependency rather than adding one.

## What the stale pin actually cost

The fork installs Claude Code via `curl ... | bash -s 1.0.115`. Every model
alias that build ships is past end-of-life. Dates read out of the Agent SDK's
own deprecation table (`b$`, the one behind
`"The model '...' is deprecated and will reach end-of-life on ..."`):

| alias in 1.0.115 | resolves to | end-of-life |
|---|---|---|
| `haiku` | `claude-3-5-haiku-20241022` | **2026-02-19** |
| `sonnet` | `claude-sonnet-4-20250514` | 2026-06-15 |
| `opus` | `claude-opus-4-1-20250805` | 2026-08-05 |

That corrects the timeline in #1525: the WebFetch 404 dates to **February**,
about 6.5 months, not the two weeks I could see. The 100-run history window
simply does not reach past 2026-08-21, and I mistook the edge of the window
for the start of the bug.

Only `haiku` is load-bearing today, because the workflow names its main model
explicitly. But `opus` went EOL four weeks ago - had anyone written
`--model opus` here, the whole edition would have died rather than degraded.

Reproduce:

```sh
npm pack @anthropic-ai/claude-agent-sdk@0.3.259 && tar xzf *.tgz
grep -o '"claude-3-5-haiku-20241022":"[^"]*"' package/sdk.mjs
```

## Why `@v1`

It is a floating tag Anthropic moves; it currently points at the 2026-09-02
commit "bump Claude Code to 2.1.259 and Agent SDK to 0.3.259". Following it is
the point - a pin is what got us here, and the fork's own bump workflow fires
on a `repository_dispatch` nobody has ever sent.

Upstream also installs through `bun install --production` from `package.json`
now, so after this there is no Claude Code version string in our tree to
forget.

## Compatibility - checked, not assumed

- All four inputs we pass exist in `action.yml` at `@v1`:
  `prompt`, `claude_args`, `claude_code_oauth_token`, `github_token`.
- All three flags we pass in `claude_args` exist in Claude Code 2.x `--help`:
  `--model`, `--allowedTools`, `--mcp-config`.
- YAML re-parsed after the edit; the step still resolves to those four inputs.

## Verify after merge

First full-curate run (duration > 90s - a gate-skip exercises none of this):

```sh
gh api repos/thevibeworks/claude-reads-hn/actions/runs/<id>/logs > /tmp/l.zip
unzip -p /tmp/l.zip '0_*' | grep -c 'API Error'                 # expect 0
unzip -p /tmp/l.zip '0_*' | grep -o '"model": "[^"]*"' | sort -u # expect opus-5 only
```

Risk is real and bounded: this jumps the runtime 1.0.115 -> 2.1.259 in one
step. If the curate step misbehaves, `verify the edition landed` fails the run
and `ci-alert.sh` opens an issue, and reverting is a one-line change back to
the fork.

## Needs a human

The fork has no commits, no consumers after this merges, and no purpose.
Archive or delete it - I have not touched it, and that is @lroolle's call.
