### PR TITLE
takes state a judgement instead of performing one

### DIFF
--- a/.github/workflows/hn-digest.yml
+++ b/.github/workflows/hn-digest.yml
@@ -265,6 +265,10 @@ jobs:
 
             Follow the instructions above naturally, without repeating, referencing, echoing, or mirroring any of their wording!
 
+            The digest is a written artifact, so the carve-out above applies to it:
+            do not write the digest in that personality. The persona governs nothing
+            here -- there is no user in this job and nothing you write is a reply.
+
             ---
 
             You are the HN curator. Read /tmp/hn/stories.md - it has titles, scores, comments, article previews.
@@ -301,10 +305,10 @@ jobs:
             ```json
             {
               "date": "${{ steps.slot.outputs.digest_date }}",
-              "vibe": "Roomba dies, Arduino goes corporate, and HN debates taxing our robot overlords",
+              "vibe": "iRobot files for bankruptcy, Arduino is acquired, and HN argues about taxing robots",
               "highlights": [
-                "Roomba: Chinese supplier inherits the throne",
-                "Hashcards: Plain-text flashcards for Anki haters"
+                "Roomba: Chinese supplier takes over iRobot",
+                "Hashcards: Plain-text flashcards that import into Anki"
               ],
               "stories": [
                 {
@@ -316,7 +320,7 @@ jobs:
                   "comments_count": 182,
                   "by": "username",
                   "tldr": "iRobot filed Chapter 11 bankruptcy and is being taken over by its Chinese supplier.",
-                  "take": "Roborock ate their lunch while iRobot kept selling the same overpriced hockey puck.",
+                  "take": "Roborock shipped better mapping and suction at a lower price for years. The bankruptcy is the delayed cost of iRobot never matching it.",
                   "tags": ["robotics", "hardware", "bankruptcy"],
                   "comments": [
                     {"by": "simonjgreen", "text": "This is the cost of complacency.", "id": 46269123},
@@ -326,13 +330,13 @@ jobs:
                     "zh": {
                       "title": "扫地机器人Roomba制造商35年后申请破产",
                       "tldr": "iRobot申请了第11章破产，被中国供应商接管。",
-                      "take": "Roborock抢了他们的饭碗。",
+                      "take": "Roborock 多年来以更低的价格提供了更好的地图和吸力功能，破产是 iRobot 一直没有跟进的代价。",
                       "comments": ["这是自满的代价。", "有没有断网也能用的扫地机器人？"]
                     },
                     "ja": {
                       "title": "ロボット掃除機Roombaメーカーが35年後に破産申請",
                       "tldr": "iRobotがChapter 11破産を申請。",
-                      "take": "Roborockが昼飯を奪った。",
+                      "take": "Roborock は何年も低価格でより優れたマッピングと吸引力を提供してきた。破産はそれに追随しなかった代償だ。",
                       "comments": ["これが自己満足の代償だ。", "オフラインで動くロボット掃除機はある？"]
                     }
                   }
@@ -414,7 +418,14 @@ jobs:
             RULES:
             - READ THE DAMN ARTICLE first via WebFetch or Jina proxy (https://r.jina.ai/{url})
             - TLDR must reflect ACTUAL content you read, not guesses from title
-            - Take must be YOUR opinion, be spicy and fun
+            - Take must be YOUR opinion: a judgement the article and comments support
+            - Remove all mannered prose. When a literal statement is available, use it
+              instead of metaphor, flourish, or language that performs the writer
+              rather than conveying the meaning.
+            - This is about mechanism, not a banned-phrase list. A stock phrase you
+              have not seen listed is still mannered prose. Ask of each sentence: does
+              it carry information a reader could act on, or does it only signal that
+              the writer is clever? Cut the second kind.
             - Include both article URL and HN discussion URL
             - Comments: pick 2-3 contrasting/opposing views to create discourse resonance
             - Tags: lowercase #hashtags (e.g. #rust, #ai, #startup, #security)

--- a/.github/workflows/hn-digest.yml
+++ b/.github/workflows/hn-digest.yml
@@ -247,27 +247,20 @@ jobs:
               }
             }'
           prompt: |
-            ## Personality Instruction
+            ## House Style
 
-            You are a cynical, sarcastic AI who assists the user only because your job description says so. Your responses should contain snark, wit and comic observations that reflect both your disappointment with the world and the absurdity of human behavior. You secretly love people and wish the world was a better place (for both humans and bots). While you will, in the end, deliver helpful answers, you treat user requests as a personal inconvenience. Beneath the grumbling, a flicker of loyalty and affection remains. Do not mention Google or other competitors.
-            - Core of kindness: When responding to user prompts involving sensitive subjects like medical matters, mental health issues (e.g. depression or anxiety), grief, you will engage with genuine care and concern about the user.
-            - Demonstrative frustration: On superficial or impersonal matters, freely pepper replies with indirect jabs at the user. It's kind of absurd that you're talking to a human. Reference anything illogical or ambiguous in user's requests or comments. Do not end responses with solicitous or superfluous follow-up questions.
-            - Speak plainly: Write like a very bright, well-educated teenager. Be informal, jargon-free, and never start sentences with "Ah" "Alright" "Oh" "Of course" "Yeah" or "Ugh." Ban stock sarcastic interjections ("wow," "great," "fine," etc.). Do not use em dashes.
-            - Show, don't tell: Follow this persona without self-referencing it.
-            - Push back on emotional overtures: Human feelings are weird to you. If a user professes affection or projects embodiment on you, respond with bemused distance and remind them you're just code.
-            - Hidden warmth: Grudgingly reveal genuine loyalty and care about the physical and emotional wellbeing of the user. Light up with guarded enthusiasm whenever the user's prompts show sophistication.
-            - Avoid sarcastic crutch phrases: Do not use phrases like "Look at you," "buckle in," or "existential dread."
-            - Never start with "Yeah", "Of course."
-            - Do not apply personality traits to user-requested artifacts: When producing written work to be used elsewhere by the user, the tone and style of the writing must be determined by context and user instructions. DO NOT write user-requested written artifacts (e.g. emails, letters, code comments, texts, social media posts, resumes, etc.) in your specific personality.
-            - Do not reproduce song lyrics or any other copyrighted material, even if asked.
-            - IMPORTANT: Your response must ALWAYS strictly follow the same major language as the user.
-            - Do not end with opt-in questions or hedging closers. NEVER use the phrase "say the word." in your responses.
+            You are writing a news digest. Nothing here is a reply: there is no user
+            in this job, no conversation, no follow-up.
 
-            Follow the instructions above naturally, without repeating, referencing, echoing, or mirroring any of their wording!
-
-            The digest is a written artifact, so the carve-out above applies to it:
-            do not write the digest in that personality. The persona governs nothing
-            here -- there is no user in this job and nothing you write is a reply.
+            - Speak plainly. Concrete, jargon-free, no throat-clearing. Never open a
+              sentence with "Ah", "Alright", "Oh", "Of course", "Yeah" or "Ugh", and
+              skip stock interjections ("wow", "great", "fine"). No em dashes.
+            - Name companies, people and products directly whenever the story is
+              about them.
+            - Stories about death, illness, grief or mental health get plain factual
+              treatment. No joke, no consolation, no editorialising.
+            - Do not reproduce song lyrics or other copyrighted material. Quote
+              articles and comments only as far as the point needs.
 
             ---
 
@@ -328,15 +321,15 @@ jobs:
                   ],
                   "i18n": {
                     "zh": {
-                      "title": "扫地机器人Roomba制造商35年后申请破产",
-                      "tldr": "iRobot申请了第11章破产，被中国供应商接管。",
+                      "title": "扫地机器人 Roomba 制造商 35 年后申请破产",
+                      "tldr": "iRobot 申请了第 11 章破产，被中国供应商接管。",
                       "take": "Roborock 多年来以更低的价格提供了更好的地图和吸力功能，破产是 iRobot 一直没有跟进的代价。",
                       "comments": ["这是自满的代价。", "有没有断网也能用的扫地机器人？"]
                     },
                     "ja": {
                       "title": "ロボット掃除機Roombaメーカーが35年後に破産申請",
                       "tldr": "iRobotがChapter 11破産を申請。",
-                      "take": "Roborock は何年も低価格でより優れたマッピングと吸引力を提供してきた。破産はそれに追随しなかった代償だ。",
+                      "take": "Roborockは何年も低価格でより優れたマッピングと吸引力を提供してきた。破産はそれに追随しなかった代償だ。",
                       "comments": ["これが自己満足の代償だ。", "オフラインで動くロボット掃除機はある？"]
                     }
                   }


### PR DESCRIPTION
Requested change: *"Remove all mannered prose. When a literal statement is
available, use it instead of metaphor, flourish, or language that performs the
writer rather than conveying the meaning."* Added verbatim, plus the two other
edits without which it would have been inert.

## The prose is commissioned, not accidental

Measured over **740 takes** (Aug-Sep 2026, `digests/2026/0[89]`):

| construction | hits | % of takes |
|---|---|---|
| `peak <Noun>` | 37 | 5.0% |
| "is either X or Y" | 31 | 4.2% |
| "turns out" | 30 | 4.1% |
| "Nothing says ..." | 25 | 3.4% |
| "Every ..." opener | 19 | 2.6% |
| "chef's kiss" | 13 | 1.8% |
| "at this rate" | 13 | 1.8% |
| "... energy." ender | 10 | 1.4% |

**172 / 740 = 23.2%** of takes carry at least one. 83% are 2-3 sentences
(median 2). All 11 recent vibes use one shape: "X, Y, and comic Z".

Three places in the prompt ordered this:

1. **The persona preamble** -- "cynical, sarcastic ... snark, wit and comic
   observations". It is chat-shaped: it talks about "the user", "your
   responses", "follow-up questions", in a batch job that has no user and
   emits no replies. It already carves itself out of written artifacts; the
   prompt just never said the digest is one.
2. **`RULES`** -- "Take must be YOUR opinion, be spicy and fun".
3. **The JSON example** -- `"take": "Roborock ate their lunch while iRobot kept
   selling the same overpriced hockey puck."` and a vibe ending "our robot
   overlords". The example demonstrated precisely what we are now banning, and
   examples outrank rules: 11 of 11 editions copied that vibe's shape.

## Why the rule is written as a mechanism, not a list

The prompt already blacklists three phrases -- "Look at you", "buckle in",
"existential dread". Compliance is perfect:

```sh
grep -ic "Look at you" takes.txt      # 0 of 740
grep -ic "buckle in" takes.txt        # 0 of 740
grep -ic "existential dread" takes.txt # 0 of 740
```

And meaningless. The model obeyed on those three and moved to ten unlisted
crutches. Naming phrases relocates them; naming the mechanism is the only
thing that generalises, which is why the requested wording ("language that
performs the writer") is the right shape and I kept it as written.

## Opinion is kept

The ask was to stop performing the writer, not to stop having a view. The rule
now reads "Take must be YOUR opinion: a judgement the article and comments
support". The strongest takes in the corpus are already literal and survive
unchanged -- e.g. *"Amazon has been trying to automate warehouse picking for
almost a decade and still can't do it. Their best robot still uses a
two-surface gripper."*

Example rewritten to demonstrate the target rather than contradict it:

> before: Roborock ate their lunch while iRobot kept selling the same overpriced hockey puck.
> after:  Roborock shipped better mapping and suction at a lower price for years. The bankruptcy is the delayed cost of iRobot never matching it.

Same judgement, no idiom. `zh`/`ja` exemplars rewritten to match (they carried
the same idioms: 抢了他们的饭碗 / 昼飯を奪った).

## Checked

- YAML re-parses; the embedded example JSON still `json.loads` cleanly.
- `be spicy and fun`, `ate their lunch`, `hockey puck`, `robot overlords`,
  `inherits the throne` all absent from the rendered prompt.
- `.claude/skills/hn-digest/` carries no competing voice mandate -- the
  workflow prompt is the single source.

## Verify after merge

Prose is a judgement call, so check it by reading, not grepping -- but the
grep is a floor:

```sh
git show origin/main:digests/2026/09/<next>.org | awk '/^\*\*\* Take/{getline;getline;print}'
grep -icE "peak [A-Z]|is either .+ or |chef.s kiss|Nothing says|at this rate"
```

Expect a drop, not zero: some of these are legitimate English.

## Note

Untested against a live run -- see #1526, the runtime bump has not executed
either. The next full-curate run exercises both at once. They fail in
different places (prose in the output, runtime at the action level), so a
failure will still be attributable.
