### PR TITLE
the edition belongs to a slot, not to whenever a trigger fired

### DIFF
--- a/.github/scripts/edition-slot.py
+++ b/.github/scripts/edition-slot.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Decide which contracted edition slot, if any, this run should publish.
+
+The repo promises four editions a day at fixed hours. Two things dispatch this
+workflow: a Cloudflare Worker that fires on time, and GitHub's own `schedule:`,
+which on this repo runs a median 4 hours late (28 scheduled runs, 2026-09-03..09,
+min 0h19m, max 4h54m). The old gate deduped on "an edition already exists for
+this UTC hour" plus a cap of four a day, and a 4-hour-late run collides with
+neither: it lands in an empty hour, the count is still under the cap, so it
+publishes. The two triggers then spent the day's four editions between 01:00 and
+11:00 UTC and the evening slot got nothing -- zero editions after 11:00 UTC on
+five consecutive days, while every run stayed green.
+
+So identity moves from "when did this run happen" to "which slot is it filling".
+A run serves the latest slot at or before now; whoever arrives first fills it and
+everyone else for that slot is a no-op. The late cron stops being a second
+scheduler competing for budget and becomes what redundancy should be: it
+publishes only when the Worker missed that slot.
+
+MAX_LATE_HOURS bounds the back-fill. Floor assignment already caps lateness at
+the gap to the next slot (5h between the daytime slots), so this only governs the
+overnight gap: without it, a 00:30 run would fill yesterday's 16:00 slot with
+today's front page, filed under yesterday.
+"""
+
+import os
+import re
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+# Keep in step with the `schedule:` block in hn-digest.yml and with the
+# Cloudflare Worker's dispatch times: these hours are the published contract
+# ("4x daily", 09:00/14:00/19:00/00:00 +8), and a trigger that fires for an hour
+# no slot claims is a run that does nothing.
+SLOTS = [int(h) for h in os.environ.get("EDITION_SLOTS", "1,6,11,16").split(",")]
+MAX_LATE = timedelta(hours=float(os.environ.get("MAX_LATE_HOURS", "6")))
+DIGESTS = Path("digests")
+
+
+def slot_for(now: datetime) -> datetime:
+    """The latest contracted slot at or before `now`, wrapping to yesterday."""
+    today = now.replace(minute=0, second=0, microsecond=0)
+    candidates = [today.replace(hour=h) for h in SLOTS]
+    candidates += [c - timedelta(days=1) for c in candidates]
+    return max(c for c in candidates if c <= now)
+
+
+def published_slots(day: datetime) -> set[datetime]:
+    """Slots already filled on `day`, by floor-assigning each edition's stamp.
+
+    New editions are named for their slot, so the name alone would answer this.
+    Editions written before this gate carry their wall-clock minute (0543, 1055),
+    and a legacy file has to count against the slot it actually served or the
+    cutover day publishes an extra edition.
+    """
+    filled = set()
+    for path in sorted(DIGESTS.glob(f"{day:%Y/%m}/{day:%d}-*.org")):
+        m = re.fullmatch(r"(\d{2})-(\d{2})(\d{2})", path.stem)
+        if not m:
+            continue
+        stamp = day.replace(hour=int(m.group(2)), minute=int(m.group(3)))
+        filled.add(slot_for(stamp))
+    return filled
+
+
+def main() -> int:
+    now = datetime.now(timezone.utc)
+    slot = slot_for(now)
+    late = now - slot
+    out = []
+
+    def emit(**kw):
+        out.extend(f"{k}={v}" for k, v in kw.items())
+
+    print(f"now {now:%Y-%m-%dT%H:%MZ}; serving slot {slot:%Y-%m-%dT%H:%MZ} "
+          f"({late.total_seconds() / 3600:.1f}h late); slots {SLOTS}")
+
+    if late > MAX_LATE:
+        print(f"slot {slot:%Y-%m-%dT%H:%MZ} is forfeit: "
+              f"{late.total_seconds() / 3600:.1f}h late exceeds {MAX_LATE}")
+        emit(skip="true")
+    else:
+        filled = published_slots(slot) | published_slots(slot + timedelta(days=1))
+        if slot in filled:
+            print(f"slot {slot:%Y-%m-%dT%H:%MZ} already published; nothing to do")
+            emit(skip="true")
+        else:
+            print(f"slot {slot:%Y-%m-%dT%H:%MZ} is open, publishing")
+            emit(
+                skip="false",
+                digest_date=f"{slot:%Y-%m-%dT%H:%M:00Z}",
+                digest_path=f"digests/{slot:%Y/%m/%d-%H%M}.org",
+                page_path=f"e/{slot:%Y/%m/%d-%H%M}.html",
+                anchor=f"{slot:%m%d%H%M}",
+                display=f"{slot:%Y-%m-%d %H:%M}",
+            )
+
+    target = os.environ.get("GITHUB_OUTPUT")
+    if target:
+        with open(target, "a") as fh:
+            fh.write("\n".join(out) + "\n")
+    else:
+        print("\n".join(out))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/hn-digest.yml
+++ b/.github/workflows/hn-digest.yml
@@ -42,58 +42,15 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
 
-      # Enforces the 4x/day contract at the point of publication rather than
-      # trusting the triggers. The per-hour check alone never did: this repo
-      # published 8 digests a day for months because a second scheduler fired
-      # on different hours, and GitHub's own cron drifts 1-3 hours, so "same
-      # hour" does not identify a duplicate. A daily cap does, and it holds no
-      # matter how many things dispatch this workflow.
-      - name: check digest quota for today
-        id: check-digest
-        run: |
-          MAX_PER_DAY=4
-          HOUR_PREFIX=$(date -u +%Y/%m/%d-%H)
-          DAY_PREFIX=$(date -u +%Y/%m/%d)
-
-          EXISTING=$(ls digests/$HOUR_PREFIX*.org digests/$HOUR_PREFIX*.md 2>/dev/null || true)
-          if [ -n "$EXISTING" ]; then
-            echo "Digest already exists for this hour: $EXISTING"
-            echo "skip=true" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-
-          TODAY_COUNT=$(ls digests/$DAY_PREFIX-*.org digests/$DAY_PREFIX-*.md 2>/dev/null | wc -l | tr -d ' ')
-          if [ "$TODAY_COUNT" -ge "$MAX_PER_DAY" ]; then
-            echo "Already published $TODAY_COUNT digests today (cap $MAX_PER_DAY); skipping."
-            echo "skip=true" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-
-          echo "No digest for hour $HOUR_PREFIX; $TODAY_COUNT/$MAX_PER_DAY published today, proceeding"
-          echo "skip=false" >> $GITHUB_OUTPUT
-
-      # The workflow owns the edition's timestamp. Left to pick `date` itself,
-      # the curator got it wrong in 19 of 30 consecutive editions (hours off,
-      # sometimes the wrong day): files landed under the wrong day, the daily
-      # cap admitted a fifth edition, and "Nth of N today" on the site was
-      # fiction. One value, computed once, and the file path, #+DATE header,
-      # story anchors, notification links and commit message all derive from
-      # it. json2org.py enforces DIGEST_DATE/DIGEST_PATH even if the curator
-      # writes something else into the JSON.
-      - name: fix the edition slot
+      # One step decides the edition's identity: which contracted slot this run
+      # serves, or whether the slot is already filled and there is nothing to do.
+      # The rules and the evidence behind them live in the script.
+      - name: claim the edition slot
         id: slot
-        if: steps.check-digest.outputs.skip != 'true'
-        run: |
-          NOW=$(date -u +%s)
-          echo "digest_date=$(date -u -d @$NOW +%Y-%m-%dT%H:%M:00Z)" >> $GITHUB_OUTPUT
-          echo "digest_path=digests/$(date -u -d @$NOW +%Y/%m/%d-%H%M).org" >> $GITHUB_OUTPUT
-          echo "anchor=$(date -u -d @$NOW +%m%d%H%M)" >> $GITHUB_OUTPUT
-          echo "display=$(date -u -d @$NOW '+%Y-%m-%d %H:%M')" >> $GITHUB_OUTPUT
-          echo "page_path=e/$(date -u -d @$NOW +%Y/%m/%d-%H%M).html" >> $GITHUB_OUTPUT
-          echo "edition slot: $(date -u -d @$NOW +%Y-%m-%dT%H:%M:00Z)"
+        run: .github/scripts/edition-slot.py
 
       - name: fetch hacker news with content
-        if: steps.check-digest.outputs.skip != 'true'
+        if: steps.slot.outputs.skip != 'true'
         run: |
           TARGET_COUNT="${{ inputs.story_count || '20' }}"
           echo "target: $TARGET_COUNT stories for Claude to evaluate"
@@ -194,18 +151,18 @@ jobs:
           wc -l /tmp/hn/stories.md
 
       - name: setup git
-        if: steps.check-digest.outputs.skip != 'true'
+        if: steps.slot.outputs.skip != 'true'
         run: |
           git config user.name "claude-yolo[bot]"
           git config user.email "claude-yolo[bot]@users.noreply.github.com"
 
       - name: clear claude locks
-        if: steps.check-digest.outputs.skip != 'true'
+        if: steps.slot.outputs.skip != 'true'
         run: rm -rf ~/.local/state/claude/locks ~/.claude/.locks
 
       - name: let claude curate
         id: curate
-        if: steps.check-digest.outputs.skip != 'true'
+        if: steps.slot.outputs.skip != 'true'
         timeout-minutes: 25
         uses: anthropics/claude-code-action@v1
         env:
@@ -450,7 +407,7 @@ jobs:
       # anything, so until now "success" and "did nothing" were the same
       # colour. Assert the artifact, not the exit code.
       - name: verify the edition landed
-        if: steps.check-digest.outputs.skip != 'true'
+        if: steps.slot.outputs.skip != 'true'
         run: |
           git fetch -q origin main
           missing=0
@@ -477,7 +434,7 @@ jobs:
       # number that decides whether this account needs its own seat.
       - name: classify the failure
         id: why
-        if: failure() && steps.check-digest.outputs.skip != 'true'
+        if: failure() && steps.slot.outputs.skip != 'true'
         run: |
           f="${{ steps.curate.outputs.execution_file }}"
           reason=defect
@@ -500,13 +457,13 @@ jobs:
           echo "reason=$reason" >> $GITHUB_OUTPUT
 
       - name: alert on failure
-        if: failure() && steps.check-digest.outputs.skip != 'true'
+        if: failure() && steps.slot.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: .github/scripts/ci-alert.sh open "${{ github.run_id }}" "${{ steps.why.outputs.reason }}"
 
       - name: clear alert on success
-        if: success() && steps.check-digest.outputs.skip != 'true'
+        if: success() && steps.slot.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: .github/scripts/ci-alert.sh close


### PR DESCRIPTION
## The symptom

Zero editions after 11:00 UTC on 09-05, 09-06, 09-07 and 09-08. Every run in that window reported success.

```
editions per day (UTC HHMM)
  2026-09-05  0100 0524 0600 1015        nothing from 10:15 to next 01:00
  2026-09-06  0100 0540 0600 1035        "
  2026-09-07  0100 0550 0600 1100        "
  2026-09-08  0100 0543 0600 1055 1103   five, and the cap is four
```

A reader in the Americas sees nothing new across their entire working day. The repo promises "4x daily"; it delivers 4x daily inside a 10-hour window.

## The cause

Two things dispatch this workflow. The Cloudflare Worker fires on time at 01/06/11/20 UTC. GitHub's own `schedule:` runs a **median 4h00m late** on this repo:

```
n=28 scheduled runs, 2026-09-03..09-09
median +4h00m   min +0h19m   max +4h54m
  09-08 05:43Z  <- the 01:00 cron, 4h43m late
  09-08 10:54Z  <- the 06:00 cron, 4h54m late
  09-08 14:59Z  <- the 11:00 cron, 3h59m late
  09-08 19:08Z  <- the 16:00 cron, 3h08m late
```

The old gate deduped on "an edition already exists for this UTC hour", plus a cap of four a day. A 4-hour-late run collides with neither test: the hour it lands in is empty, and the count is still under the cap. So it publishes. The Worker and the drifted cron spend the day's four editions between 01:00 and 11:00, and the 16:00 / 20:00 triggers arrive to find the budget gone.

The cap also lost its own race twice (08-27 and 09-08 each published five): two runs can pass the count check before either one commits.

## The change

Identity moves from *when did this run happen* to *which slot is it filling*. A run serves the latest contracted slot at or before now. The first arrival fills it; every later trigger for that slot is a no-op. `MAX_LATE_HOURS` (6h) bounds back-fill, so a 00:30 run cannot fill yesterday's evening slot with today's front page.

The late cron stops being a second scheduler competing for budget and becomes what redundancy is supposed to be: it publishes only when the Worker missed that slot.

Two steps (`check digest quota for today`, `fix the edition slot`) collapse into one, `claim the edition slot`, with the rules and this evidence in `.github/scripts/edition-slot.py` instead of inline bash.

## Verification

All 32 real triggers from 09-05..09-08, replayed through the new gate:

```
2026-09-05: 0100(worker)  0600(worker)  1100(worker)  1600(cron @17:49)
2026-09-06: 0100(worker)  0600(worker)  1100(worker)  1600(cron @17:53)
2026-09-07: 0100(worker)  0600(worker)  1100(worker)  1600(cron @16:19)
2026-09-08: 0100(worker)  0600(worker)  1100(worker)  1600(cron @19:08)

16 editions from 32 triggers. Four a day, no slot filled twice, no cap breach.
```

Three slots from the Worker, the evening one from the cron that is too late to serve anything else. Every decision is printed in the run log, so a wrong verdict is visible rather than silent.

## What this unblocks

#1495 wanted the `schedule:` block deleted because the two schedulers race. They no longer race, so removing the cron becomes optional cleanup rather than a prerequisite -- and keeping it costs nothing while the Worker's classic PAT is still unrotated.

Worth doing separately: move the Worker's 4th dispatch from 20:00 to 16:00 UTC so the evening edition lands on time instead of waiting for the late cron to cover it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
